### PR TITLE
Fixes ImportError `FileWrapper`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ install:
 script:
     - tox
 env:
+    - TOXENV=py34-1.9
+    - TOXENV=py27-1.9
+    - TOXENV=py34-1.8
+    - TOXENV=py27-1.8
     - TOXENV=py34-1.7
     - TOXENV=py27-1.7
     - TOXENV=py34-1.6

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,12 @@ deps =
 envlist =
     py27-1.6,
     py27-1.7,
+    py27-1.8,
+    py27-1.9,
     py34-1.6,
-    py34-1.7
+    py34-1.7,
+    py34-1.8,
+    py34-1.9
 
 [testenv]
 usedevelop = True
@@ -33,6 +37,19 @@ deps =
     Django>=1.7,<1.8
     {[base]deps}
 
+[testenv:py27-1.8]
+basepython = python2.7
+deps =
+    Django>=1.8,<1.9
+    {[base]deps}
+
+[testenv:py27-1.9]
+basepython = python2.7
+deps =
+    Django>=1.9,<1.10
+    {[base]deps}
+
+
 [testenv:py34-1.6]
 basepython = python3.4
 deps =
@@ -43,4 +60,16 @@ deps =
 basepython = python3.4
 deps =
     Django>=1.7,<1.8
+    {[base]deps}
+
+[testenv:py34-1.8]
+basepython = python3.4
+deps =
+    Django>=1.8,<1.9
+    {[base]deps}
+
+[testenv:py34-1.9]
+basepython = python3.4
+deps =
+    Django>=1.9,<1.10
     {[base]deps}

--- a/zipview/views.py
+++ b/zipview/views.py
@@ -2,14 +2,13 @@
 
 from __future__ import unicode_literals
 
-import os
 import zipfile
-from io import BytesIO
 
 from django.views.generic import View
 from django.http import HttpResponse
 from django.core.files.base import ContentFile
 from django.utils.six import b
+
 
 class BaseZipView(View):
     """A base view to zip and stream several files."""


### PR DESCRIPTION
fixes #2, ImportError for FileWrapper (an undocumented, unsupported, and now removed function)
Should work on older djangos (1.8 etc) too.
Tested on Django 1.9a1, Python 3.4.3 (default, Aug 10 2015, 16:40:44) [GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.56)] on darwin (MacOS X 10.9.5, via Hombrew)
